### PR TITLE
<CARRY>: CNTRLPLANE-211: Add Prow and Konflux compatible Dockerfiles

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
-build/
 develop-eggs/
 dist/
 downloads/
@@ -111,8 +109,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
-build/
 develop-eggs/
 dist/
 downloads/

--- a/.tekton/kubernetes-sigs-jobset-pull-request.yaml
+++ b/.tekton/kubernetes-sigs-jobset-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: /Dockerfile
+    value: /Dockerfile.ocp
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/kubernetes-sigs-jobset-push.yaml
+++ b/.tekton/kubernetes-sigs-jobset-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/jobset-lws-pipeline-tenant/kubernetes-sigs-jobset:{{revision}}
   - name: dockerfile
-    value: /Dockerfile
+    value: /Dockerfile.ocp
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,40 @@
+ARG BUILDER_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19
+ARG BASE_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.19
+
+# Build the manager binary
+FROM ${BUILDER_IMAGE} AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETPLATFORM
+
+ENV GOEXPERIMENT=strictfipsruntime
+
+WORKDIR /workspace
+COPY . .
+
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -mod=vendor -a -o manager main.go
+
+FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
+WORKDIR /
+COPY --from=builder /workspace/manager .
+RUN mkdir /licenses
+COPY --from=builder /workspace/LICENSE /licenses/.
+USER 65532:65532
+
+LABEL com.redhat.component="Job Set"
+LABEL name="jobset"
+LABEL release="0.8.0"
+LABEL version="0.8.0"
+LABEL url="https://github.com/openshift/kubernetes-sigs-jobset"
+LABEL vendor="Red Hat, Inc."
+LABEL description="JobSet is a Kubernetes-native API for managing a group of k8s Jobs as a unit. \
+                   It aims to offer a unified API for deploying HPC (e.g., MPI) and AI/ML training workloads (PyTorch, Jax, Tensorflow etc.) on Kubernetes."
+LABEL io.k8s.description="JobSet is a Kubernetes-native API for managing a group of k8s Jobs as a unit. \
+                   It aims to offer a unified API for deploying HPC (e.g., MPI) and AI/ML training workloads (PyTorch, Jax, Tensorflow etc.) on Kubernetes."
+LABEL summary="JobSet is a Kubernetes-native API for managing a group of k8s Jobs as a unit. \
+                   It aims to offer a unified API for deploying HPC (e.g., MPI) and AI/ML training workloads (PyTorch, Jax, Tensorflow etc.) on Kubernetes."
+LABEL io.k8s.display-name="Job Set"
+LABEL io.openshift.tags="openshift,operator,jobset"
+
+ENTRYPOINT ["/manager"]

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,40 @@
+ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23
+ARG BASE_IMAGE=registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
+
+# Build the manager binary
+FROM ${BUILDER_IMAGE} AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETPLATFORM
+
+ENV GOEXPERIMENT=strictfipsruntime
+
+WORKDIR /workspace
+COPY . .
+
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -mod=vendor -a -o manager main.go
+
+FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
+WORKDIR /
+COPY --from=builder /workspace/manager .
+RUN mkdir /licenses
+COPY --from=builder /workspace/LICENSE /licenses/.
+USER 65532:65532
+
+LABEL com.redhat.component="Job Set"
+LABEL name="jobset"
+LABEL release="0.8.0"
+LABEL version="0.8.0"
+LABEL url="https://github.com/openshift/kubernetes-sigs-jobset"
+LABEL vendor="Red Hat, Inc."
+LABEL description="JobSet is a Kubernetes-native API for managing a group of k8s Jobs as a unit. \
+                   It aims to offer a unified API for deploying HPC (e.g., MPI) and AI/ML training workloads (PyTorch, Jax, Tensorflow etc.) on Kubernetes."
+LABEL io.k8s.description="JobSet is a Kubernetes-native API for managing a group of k8s Jobs as a unit. \
+                   It aims to offer a unified API for deploying HPC (e.g., MPI) and AI/ML training workloads (PyTorch, Jax, Tensorflow etc.) on Kubernetes."
+LABEL summary="JobSet is a Kubernetes-native API for managing a group of k8s Jobs as a unit. \
+                   It aims to offer a unified API for deploying HPC (e.g., MPI) and AI/ML training workloads (PyTorch, Jax, Tensorflow etc.) on Kubernetes."
+LABEL io.k8s.display-name="Job Set"
+LABEL io.openshift.tags="openshift,operator,jobset"
+
+ENTRYPOINT ["/manager"]

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,11 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - ahg-g
-  - danielvegamyhre
 reviewers:
+  - ardaguclu
+  - atiratree
   - kannon92
+  - mrunalp
+approvers:
+  - ardaguclu
+  - atiratree
+  - kannon92
+  - mrunalp
+component: "kubernetes-sigs-jobset"

--- a/vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go
+++ b/vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go
@@ -1,0 +1,76 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/onsi/ginkgo/v2/ginkgo/command"
+	"github.com/onsi/ginkgo/v2/ginkgo/internal"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+func BuildBuildCommand() command.Command {
+	var cliConfig = types.NewDefaultCLIConfig()
+	var goFlagsConfig = types.NewDefaultGoFlagsConfig()
+
+	flags, err := types.BuildBuildCommandFlagSet(&cliConfig, &goFlagsConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	return command.Command{
+		Name:     "build",
+		Flags:    flags,
+		Usage:    "ginkgo build <FLAGS> <PACKAGES>",
+		ShortDoc: "Build the passed in <PACKAGES> (or the package in the current directory if left blank).",
+		DocLink:  "precompiling-suites",
+		Command: func(args []string, _ []string) {
+			var errors []error
+			cliConfig, goFlagsConfig, errors = types.VetAndInitializeCLIAndGoConfig(cliConfig, goFlagsConfig)
+			command.AbortIfErrors("Ginkgo detected configuration issues:", errors)
+
+			buildSpecs(args, cliConfig, goFlagsConfig)
+		},
+	}
+}
+
+func buildSpecs(args []string, cliConfig types.CLIConfig, goFlagsConfig types.GoFlagsConfig) {
+	suites := internal.FindSuites(args, cliConfig, false).WithoutState(internal.TestSuiteStateSkippedByFilter)
+	if len(suites) == 0 {
+		command.AbortWith("Found no test suites")
+	}
+
+	internal.VerifyCLIAndFrameworkVersion(suites)
+
+	opc := internal.NewOrderedParallelCompiler(cliConfig.ComputedNumCompilers())
+	opc.StartCompiling(suites, goFlagsConfig)
+
+	for {
+		suiteIdx, suite := opc.Next()
+		if suiteIdx >= len(suites) {
+			break
+		}
+		suites[suiteIdx] = suite
+		if suite.State.Is(internal.TestSuiteStateFailedToCompile) {
+			fmt.Println(suite.CompilationError.Error())
+		} else {
+			if len(goFlagsConfig.O) == 0 {
+				goFlagsConfig.O = path.Join(suite.Path, suite.PackageName+".test")
+			} else {
+				stat, err := os.Stat(goFlagsConfig.O)
+				if err != nil {
+					panic(err)
+				}
+				if stat.IsDir() {
+					goFlagsConfig.O += "/" + suite.PackageName + ".test"
+				}
+			}
+			fmt.Printf("Compiled %s\n", goFlagsConfig.O)
+		}
+	}
+
+	if suites.CountWithState(internal.TestSuiteStateFailedToCompile) > 0 {
+		command.AbortWith("Failed to compile all tests")
+	}
+}

--- a/vendor/go.opentelemetry.io/otel/sdk/internal/env/env.go
+++ b/vendor/go.opentelemetry.io/otel/sdk/internal/env/env.go
@@ -1,0 +1,166 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package env // import "go.opentelemetry.io/otel/sdk/internal/env"
+
+import (
+	"os"
+	"strconv"
+
+	"go.opentelemetry.io/otel/internal/global"
+)
+
+// Environment variable names.
+const (
+	// BatchSpanProcessorScheduleDelayKey is the delay interval between two
+	// consecutive exports (i.e. 5000).
+	BatchSpanProcessorScheduleDelayKey = "OTEL_BSP_SCHEDULE_DELAY"
+	// BatchSpanProcessorExportTimeoutKey is the maximum allowed time to
+	// export data (i.e. 3000).
+	BatchSpanProcessorExportTimeoutKey = "OTEL_BSP_EXPORT_TIMEOUT"
+	// BatchSpanProcessorMaxQueueSizeKey is the maximum queue size (i.e. 2048).
+	BatchSpanProcessorMaxQueueSizeKey = "OTEL_BSP_MAX_QUEUE_SIZE"
+	// BatchSpanProcessorMaxExportBatchSizeKey is the maximum batch size (i.e.
+	// 512). Note: it must be less than or equal to
+	// BatchSpanProcessorMaxQueueSize.
+	BatchSpanProcessorMaxExportBatchSizeKey = "OTEL_BSP_MAX_EXPORT_BATCH_SIZE"
+
+	// AttributeValueLengthKey is the maximum allowed attribute value size.
+	AttributeValueLengthKey = "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT"
+
+	// AttributeCountKey is the maximum allowed span attribute count.
+	AttributeCountKey = "OTEL_ATTRIBUTE_COUNT_LIMIT"
+
+	// SpanAttributeValueLengthKey is the maximum allowed attribute value size
+	// for a span.
+	SpanAttributeValueLengthKey = "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT"
+
+	// SpanAttributeCountKey is the maximum allowed span attribute count for a
+	// span.
+	SpanAttributeCountKey = "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT"
+
+	// SpanEventCountKey is the maximum allowed span event count.
+	SpanEventCountKey = "OTEL_SPAN_EVENT_COUNT_LIMIT"
+
+	// SpanEventAttributeCountKey is the maximum allowed attribute per span
+	// event count.
+	SpanEventAttributeCountKey = "OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT"
+
+	// SpanLinkCountKey is the maximum allowed span link count.
+	SpanLinkCountKey = "OTEL_SPAN_LINK_COUNT_LIMIT"
+
+	// SpanLinkAttributeCountKey is the maximum allowed attribute per span
+	// link count.
+	SpanLinkAttributeCountKey = "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT"
+)
+
+// firstInt returns the value of the first matching environment variable from
+// keys. If the value is not an integer or no match is found, defaultValue is
+// returned.
+func firstInt(defaultValue int, keys ...string) int {
+	for _, key := range keys {
+		value := os.Getenv(key)
+		if value == "" {
+			continue
+		}
+
+		intValue, err := strconv.Atoi(value)
+		if err != nil {
+			global.Info("Got invalid value, number value expected.", key, value)
+			return defaultValue
+		}
+
+		return intValue
+	}
+
+	return defaultValue
+}
+
+// IntEnvOr returns the int value of the environment variable with name key if
+// it exists, it is not empty, and the value is an int. Otherwise, defaultValue is returned.
+func IntEnvOr(key string, defaultValue int) int {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+
+	intValue, err := strconv.Atoi(value)
+	if err != nil {
+		global.Info("Got invalid value, number value expected.", key, value)
+		return defaultValue
+	}
+
+	return intValue
+}
+
+// BatchSpanProcessorScheduleDelay returns the environment variable value for
+// the OTEL_BSP_SCHEDULE_DELAY key if it exists, otherwise defaultValue is
+// returned.
+func BatchSpanProcessorScheduleDelay(defaultValue int) int {
+	return IntEnvOr(BatchSpanProcessorScheduleDelayKey, defaultValue)
+}
+
+// BatchSpanProcessorExportTimeout returns the environment variable value for
+// the OTEL_BSP_EXPORT_TIMEOUT key if it exists, otherwise defaultValue is
+// returned.
+func BatchSpanProcessorExportTimeout(defaultValue int) int {
+	return IntEnvOr(BatchSpanProcessorExportTimeoutKey, defaultValue)
+}
+
+// BatchSpanProcessorMaxQueueSize returns the environment variable value for
+// the OTEL_BSP_MAX_QUEUE_SIZE key if it exists, otherwise defaultValue is
+// returned.
+func BatchSpanProcessorMaxQueueSize(defaultValue int) int {
+	return IntEnvOr(BatchSpanProcessorMaxQueueSizeKey, defaultValue)
+}
+
+// BatchSpanProcessorMaxExportBatchSize returns the environment variable value for
+// the OTEL_BSP_MAX_EXPORT_BATCH_SIZE key if it exists, otherwise defaultValue
+// is returned.
+func BatchSpanProcessorMaxExportBatchSize(defaultValue int) int {
+	return IntEnvOr(BatchSpanProcessorMaxExportBatchSizeKey, defaultValue)
+}
+
+// SpanAttributeValueLength returns the environment variable value for the
+// OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT key if it exists. Otherwise, the
+// environment variable value for OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT is
+// returned or defaultValue if that is not set.
+func SpanAttributeValueLength(defaultValue int) int {
+	return firstInt(defaultValue, SpanAttributeValueLengthKey, AttributeValueLengthKey)
+}
+
+// SpanAttributeCount returns the environment variable value for the
+// OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT key if it exists. Otherwise, the
+// environment variable value for OTEL_ATTRIBUTE_COUNT_LIMIT is returned or
+// defaultValue if that is not set.
+func SpanAttributeCount(defaultValue int) int {
+	return firstInt(defaultValue, SpanAttributeCountKey, AttributeCountKey)
+}
+
+// SpanEventCount returns the environment variable value for the
+// OTEL_SPAN_EVENT_COUNT_LIMIT key if it exists, otherwise defaultValue is
+// returned.
+func SpanEventCount(defaultValue int) int {
+	return IntEnvOr(SpanEventCountKey, defaultValue)
+}
+
+// SpanEventAttributeCount returns the environment variable value for the
+// OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT key if it exists, otherwise defaultValue
+// is returned.
+func SpanEventAttributeCount(defaultValue int) int {
+	return IntEnvOr(SpanEventAttributeCountKey, defaultValue)
+}
+
+// SpanLinkCount returns the environment variable value for the
+// OTEL_SPAN_LINK_COUNT_LIMIT key if it exists, otherwise defaultValue is
+// returned.
+func SpanLinkCount(defaultValue int) int {
+	return IntEnvOr(SpanLinkCountKey, defaultValue)
+}
+
+// SpanLinkAttributeCount returns the environment variable value for the
+// OTEL_LINK_ATTRIBUTE_COUNT_LIMIT key if it exists, otherwise defaultValue is
+// returned.
+func SpanLinkAttributeCount(defaultValue int) int {
+	return IntEnvOr(SpanLinkAttributeCountKey, defaultValue)
+}


### PR DESCRIPTION
This PR;

* Adds Prow dockerfile and ci-operator.yaml to initiate the foundational steps for testing
* Adds Konflux dockerfile to align with Prow one as well as required modifications for Konflux
* Updates OWNERS file 

We have to diverge from upstream Dockerfile due to various constraints in our platform.

This PR supersedes https://github.com/openshift/kubernetes-sigs-jobset/pull/19