### PR TITLE
<CARRY>: CNTRLPLANE-211: Revert Dockerfile to the upstream original

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,24 +6,16 @@ FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 ARG TARGETARCH
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
+# cache deps before building so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
+COPY . .
 RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY pkg/ pkg/
-
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
This PR reverts the Dockerfile to the upstream original. We don't use it in OCP and any changes in there blocks the fork syncing by raising merge conflicts.