### PR TITLE
<CARRY>: CNTRLPLANE-211: Add renovate.json to disable go mod auto update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "schedule": ["on Tuesday"],
+  "gomod": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
This PR adds renovate.json because we'll manually manage our go module updates. Automated PRs just create a lot of noise.